### PR TITLE
Add option to format on save

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "formatto",
-    "version": "1.2.8",
+    "version": "1.2.9",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "formatto",
-            "version": "1.2.8",
+            "version": "1.2.9",
             "license": "MIT",
             "devDependencies": {
                 "@rollup/plugin-alias": "^5.0.1",

--- a/src/lang/locale/_.json
+++ b/src/lang/locale/_.json
@@ -53,7 +53,9 @@
         "Notify when no change is needed": "",
         "Displays a different message when no change is needed.": "",
         "More detailed error message": "",
-        "Displays additional information when parsing fails.": ""
+        "Displays additional information when parsing fails.": "",
+        "Format documents on modification": "",
+        "Automatically format documents after each modification. Triggers on save and autosave.": ""
     },
     "wasm": {
         "parsing": {

--- a/src/lang/locale/de.json
+++ b/src/lang/locale/de.json
@@ -53,7 +53,9 @@
         "Notify when no change is needed": "",
         "Displays a different message when no change is needed.": "",
         "More detailed error message": "",
-        "Displays additional information when parsing fails.": ""
+        "Displays additional information when parsing fails.": "",
+        "Format documents on modification": "",
+        "Automatically format documents after each modification. Triggers on save and autosave.": ""
     },
     "wasm": {
         "parsing": {

--- a/src/lang/locale/en.json
+++ b/src/lang/locale/en.json
@@ -53,7 +53,9 @@
         "Notify when no change is needed": "Notify when no change is needed",
         "Displays a different message when no change is needed.": "Displays a different message when no change is needed.",
         "More detailed error message": "More detailed error message",
-        "Displays additional information when parsing fails.": "Displays additional information when parsing fails."
+        "Displays additional information when parsing fails.": "Displays additional information when parsing fails.",
+        "Format documents on modification": "Format documents on modification",
+        "Automatically format documents after each modification. Triggers on save and autosave.": "Automatically format documents after each modification. Triggers on save and autosave."
     },
     "wasm": {
         "parsing": {

--- a/src/lang/locale/hu.json
+++ b/src/lang/locale/hu.json
@@ -53,7 +53,9 @@
         "Notify when no change is needed": "Értesítsen, hogyha nem szükséges változás",
         "Displays a different message when no change is needed.": "Eltérő üzenetet mutat, hogyha nem történt változás",
         "More detailed error message": "Mutasson részletesebb hiba üzeneteket",
-        "Displays additional information when parsing fails.": "Plusz információt mutat, amikor az átírás közben hiba történik."
+        "Displays additional information when parsing fails.": "Plusz információt mutat, amikor az átírás közben hiba történik.",
+        "Format documents on modification": "",
+        "Automatically format documents after each modification. Triggers on save and autosave.": ""
     },
     "wasm": {
         "parsing": {

--- a/src/lang/locale/ko.json
+++ b/src/lang/locale/ko.json
@@ -53,7 +53,9 @@
         "Notify when no change is needed": "변경사항이 없을 때 알려주기",
         "Displays a different message when no change is needed.": "변경할 사항이 없으면 다른 메세지를 표시합니다.",
         "More detailed error message": "더 상세한 에러 메세지",
-        "Displays additional information when parsing fails.": "문서를 읽지 못했을 때 추가 정보를 표시합니다."
+        "Displays additional information when parsing fails.": "문서를 읽지 못했을 때 추가 정보를 표시합니다.",
+        "Format documents on modification": "",
+        "Automatically format documents after each modification. Triggers on save and autosave.": ""
     },
     "wasm": {
         "parsing": {

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,4 +1,4 @@
-import { Plugin } from "obsidian";
+import { Plugin, TFile } from "obsidian";
 
 import { FormattoCommands } from "@obsidian/commands";
 import { FormattoEditorMenu } from "@obsidian/events/editorMenu";
@@ -51,6 +51,16 @@ export default class FormattoPlugin extends Plugin {
         this.ribbonIcons.registerRibbonIcons();
         this.editorMenus.registerEditorMenus();
         this.commands.registerCommands();
+
+        this.registerEvent(
+            this.app.vault.on('modify', (file) => {
+                if (this.settings.otherOptions.formatOnSave && file instanceof TFile && file.extension === 'md') {
+                    this.app.vault.process(file, (data) => {
+                        return this.utils.formatText(data)
+                    });
+                }
+            }),
+        );
 
         console.log(
             "Plugin Loaded: Formatto\n(Some error details are going to be displayed here.)"

--- a/src/obsidian/options/optionTab.ts
+++ b/src/obsidian/options/optionTab.ts
@@ -389,5 +389,30 @@ export class FormattoOptionTab extends PluginSettingTab {
                         await this.plugin.saveOptions();
                     })
             );
+        new Setting(containerEl)
+            .setName(
+                getLocale(
+                    LOCALE_CATEGORY.OTHER_OPTIONS,
+                    "Format documents on modification"
+                )
+            )
+            .setDesc(
+                getLocale(
+                    LOCALE_CATEGORY.OTHER_OPTIONS,
+                    "Automatically format documents after each modification. Triggers on save and autosave."
+                )
+            )
+            .addToggle((text) =>
+                text
+                    .setValue(
+                        this.plugin.settings.otherOptions
+                            .formatOnSave
+                    )
+                    .onChange(async (value) => {
+                        this.plugin.settings.otherOptions.formatOnSave =
+                            value;
+                        await this.plugin.saveOptions();
+                    })
+            );
     }
 }

--- a/src/obsidian/options/optionTypes.ts
+++ b/src/obsidian/options/optionTypes.ts
@@ -34,6 +34,8 @@ export interface OtherOptions {
     notifyWhenUnchanged: boolean;
     /** Displays additional information when parsing fails. */
     showMoreDetailedErrorMessages: boolean;
+    /** Format document after each modification. */
+    formatOnSave: boolean;
 }
 
 export interface FormattoPluginOptions {
@@ -68,6 +70,7 @@ export const FALLBACK_FORMAT_OPTIONS: Partial<FormatOptions> = {
 export const FALLBACK_OTHER_OPTIONS: Partial<OtherOptions> = {
     notifyWhenUnchanged: true,
     showMoreDetailedErrorMessages: false,
+    formatOnSave: false,
 };
 
 export const FALLBACK_OPTIONS: FormattoPluginOptions = {

--- a/src/obsidian/utils.ts
+++ b/src/obsidian/utils.ts
@@ -43,6 +43,26 @@ export class FormattoUtils {
         this.clearVariables();
     }
 
+    formatText(data: string): string {
+        const copiedOptions = JSON.parse(JSON.stringify(this.plugin.settings));
+        this.handleEmptyOptions(copiedOptions);
+
+        this.originalDocument = data;
+
+        try {
+            this.formattedDocument = format_document(
+                this.originalDocument,
+                copiedOptions,
+                JSON.stringify(getWasmLocale())
+            );
+            return this.formattedDocument;
+        } catch (error) {
+            new Notice(error);
+        } finally {
+            this.clearVariables();
+        }
+    }
+
     private displayMessage() {
         if (
             this.plugin.settings.otherOptions.notifyWhenUnchanged &&


### PR DESCRIPTION
Allow formatting on save (and autosave). Turned off by default.

I do not have experience with obsidian and little with js/ts in general, so please make sure I did not break anything before merging.

Also, this is probably not the best way to do this and may cause obsidian to get stuck in a loop if the formatter does not converge (`vault.process()` triggers another `modify` event if there were any changes).